### PR TITLE
Add errorURL support

### DIFF
--- a/docs/authorize.md
+++ b/docs/authorize.md
@@ -46,6 +46,15 @@ authorisation issue, specific contact details, etc.
 It should be an array of key/value pairs, with the keys as the language code.
 You can use HTML in the message. See below for an example.
 
+### `errorURL`
+
+If the identity provider includes an `errorURL` in metadata, this option turns
+on or off the generation of a context-specific errorURL in accordance with the
+REFEDS SAML2 Metadata Deployment Profile for errorURL. Defaults to TRUE.
+
+**Note**: This option needs to be boolean (TRUE/FALSE) else it will be
+          considered an attribute matching rule.
+
 ## Attribute Rules
 
 Each additional filter configuration option is considered an attribute matching

--- a/src/Auth/Process/Authorize.php
+++ b/src/Auth/Process/Authorize.php
@@ -62,21 +62,21 @@ class Authorize extends Auth\ProcessingFilter
         // Must be bool specifically, if not, it might be for an attrib filter below
         if (isset($config['deny']) && is_bool($config['deny'])) {
             $this->deny = $config['deny'];
+            unset($config['deny']);
         }
 
         // Check for the regex option
         // Must be bool specifically, if not, it might be for an attrib filter below
         if (isset($config['regex']) && is_bool($config['regex'])) {
             $this->regex = $config['regex'];
+            unset($config['regex']);
         }
 
         // Check for the reject_msg option; Must be array of languages
         if (isset($config['reject_msg']) && is_array($config['reject_msg'])) {
             $this->reject_msg = $config['reject_msg'];
+            unset($config['reject_msg']);
         }
-
-        // Remove all above options
-        unset($config['deny'], $config['regex'], $config['reject_msg']);
 
         foreach ($config as $attribute => $values) {
             if (is_string($values)) {

--- a/src/Auth/Process/Authorize.php
+++ b/src/Auth/Process/Authorize.php
@@ -105,17 +105,17 @@ class Authorize extends Auth\ProcessingFilter
     /**
      * Apply filter to validate attributes.
      *
-     * @param array &$request  The current request
+     * @param array &$state  The current request
      */
-    public function process(array &$request): void
+    public function process(array &$state): void
     {
-        Assert::keyExists($request, 'Attributes');
+        Assert::keyExists($state, 'Attributes');
 
         $authorize = $this->deny;
-        $attributes = &$request['Attributes'];
-        // Store the rejection message array in the $request
+        $attributes = &$state['Attributes'];
+        // Store the rejection message array in the $state
         if (!empty($this->reject_msg)) {
-            $request['authprocAuthorize_reject_msg'] = $this->reject_msg;
+            $state['authprocAuthorize_reject_msg'] = $this->reject_msg;
         }
 
         $arrayUtils = new Utils\Arrays();
@@ -138,7 +138,7 @@ class Authorize extends Auth\ProcessingFilter
             }
         }
         if (!$authorize) {
-            $this->unauthorized($request);
+            $this->unauthorized($state);
         }
     }
 
@@ -153,12 +153,12 @@ class Authorize extends Auth\ProcessingFilter
      * thinking in case a "chained" ACL is needed, more complex
      * permission logic.
      *
-     * @param array $request
+     * @param array $state
      */
-    protected function unauthorized(array &$request): void
+    protected function unauthorized(array &$state): void
     {
         // Save state and redirect to 403 page
-        $id = Auth\State::saveState($request, 'authorize:Authorize');
+        $id = Auth\State::saveState($state, 'authorize:Authorize');
         $url = Module::getModuleURL('authorize/error/forbidden');
         $httpUtils = new Utils\HTTP();
         $httpUtils->redirectTrustedURL($url, ['StateId' => $id]);

--- a/src/Controller/Authorize.php
+++ b/src/Controller/Authorize.php
@@ -72,6 +72,12 @@ class Authorize
             $t->data['reject_msg'] = $state['authprocAuthorize_reject_msg'];
         }
 
+        if (isset($state['Source']['auth'])) {
+            $t->data['LogoutURL'] = Module::getModuleURL(
+                'saml/sp/login/' . urlencode($state['Source']['auth'])
+            );
+        }
+
         $t->setStatusCode(403);
         return $t;
     }

--- a/src/Controller/Authorize.php
+++ b/src/Controller/Authorize.php
@@ -78,6 +78,28 @@ class Authorize
             );
         }
 
+        if (
+            isset($state['authprocAuthorize_errorURL'])
+            && $state['authprocAuthorize_errorURL'] === true
+            && isset($state['Source']['errorURL'])
+        ) {
+            $errorURL = $state['Source']['errorURL'];
+            $errorURL = str_replace('ERRORURL_CODE', 'AUTHORIZATION_FAILURE', $errorURL);
+            if (isset($state['saml:sp:State']['core:SP'])) {
+                $errorURL = str_replace('ERRORURL_RP', urlencode($state['saml:sp:State']['core:SP']), $errorURL);
+            }
+            if (isset($state['saml:AuthnInstant'])) {
+                $errorURL = str_replace('ERRORURL_TS', $state['saml:AuthnInstant'], $errorURL);
+            } else {
+                $errorURL = str_replace('ERRORURL_TS', strval(time()), $errorURL);
+            }
+            $errorURL = str_replace('ERRORURL_TID', urlencode($this->session->getTrackID()), $errorURL);
+            if (isset($state['authprocAuthorize_ctx'])) {
+                $errorURL = str_replace('ERRORURL_CTX', urlencode($state['authprocAuthorize_ctx']), $errorURL);
+            }
+            $t->data['errorURL'] = $errorURL;
+        }
+
         $t->setStatusCode(403);
         return $t;
     }

--- a/templates/authorize_403.twig
+++ b/templates/authorize_403.twig
@@ -7,9 +7,11 @@
 {% else %}
   <p>{% trans %}You don't have the needed privileges to access this application. Please contact the administrator if you find this to be incorrect.{% endtrans %}</p>
 {% endif %}
-  {% if logoutURL is defined %}
+{% if LogoutURL is defined %}
   <p>
-      <a href="{{ moduleURL('core/logout/' ~ source|url_encode) }}">{% trans %}Logout{% endtrans %}</a>
+    <a href="{{ LogoutURL }}">
+      <button class="pure-button pure-button-red">{% trans %}Logout{% endtrans %}</button>
+    </a>
   </p>
-  {% endif %}
+{% endif %}
 {% endblock%}

--- a/templates/authorize_403.twig
+++ b/templates/authorize_403.twig
@@ -7,6 +7,15 @@
 {% else %}
   <p>{% trans %}You don't have the needed privileges to access this application. Please contact the administrator if you find this to be incorrect.{% endtrans %}</p>
 {% endif %}
+{% if errorURL is defined %}
+  <p>
+    {% trans %}Your identity provider provides additional information that may help you solve this.{% endtrans %}
+    <br>
+    <a href="{{ errorURL }}" target="_blank">
+      <button class="pure-button">{% trans %}Additional information{% endtrans %}</button>
+    </a>
+  </p>
+{% endif %}
 {% if LogoutURL is defined %}
   <p>
     <a href="{{ LogoutURL }}">

--- a/tests/src/Controller/AuthorizeTest.php
+++ b/tests/src/Controller/AuthorizeTest.php
@@ -48,7 +48,9 @@ class AuthorizeTest extends TestCase
         $state = [
             'StateId' => 'SomeState',
             'Source' => ['auth' => 'test'],
-            'authprocAuthorize_reject_msg' => 'Test Rejected'
+            'authprocAuthorize_reject_msg' => 'Test Rejected',
+            'authprocAuthorize_error_url' => true,
+            'authprocAuthorize_ctx' => 'example',
         ];
         $this->stateId = Auth\State::saveState($state, 'authorize:Authorize');
 


### PR DESCRIPTION
Following on from simplesamlphp/simplesamlphp#1425 & simplesamlphp/simplesamlphp#1841, this adds
support for redirecting users to an IdP-supplied errorURL into the authorize module.