### PR TITLE
fix(template): used wrong translation value: Re-authenticate -> Change account?

### DIFF
--- a/templates/authorize_403.twig
+++ b/templates/authorize_403.twig
@@ -13,7 +13,7 @@
 {% if allow_reauthentication is defined %}
   <p>
     <a href="{{ url_reauthentication }}">
-      <button class="pure-button pure-button-red">{% trans %}Re-authenticate{% endtrans %}</button>
+      <button class="pure-button pure-button-red">{% trans %}Change account?{% endtrans %}</button>
     </a>
   </p>
 {% endif %}


### PR DESCRIPTION
Sorry typo in the twig template:
Re-authenticate -> Change account?

I edited in my own theme, but forgot to change it in the default template.