### PR TITLE
Fix allow reauthentication always show

### DIFF
--- a/templates/authorize_403.twig
+++ b/templates/authorize_403.twig
@@ -10,7 +10,7 @@
 {% if user_attribute is defined %}
  <p>{% trans %}You are currently logged in as{% endtrans %} {{ user_attribute }}</p>
 {% endif %}
-{% if allow_reauthentication is defined %}
+{% if allow_reauthentication is defined && allow_reauthentication%}
   <p>
     <a href="{{ url_reauthentication }}">
       <button class="pure-button pure-button-red">{% trans %}Change account?{% endtrans %}</button>

--- a/templates/authorize_403.twig
+++ b/templates/authorize_403.twig
@@ -10,7 +10,7 @@
 {% if user_attribute is defined %}
  <p>{% trans %}You are currently logged in as{% endtrans %} {{ user_attribute }}</p>
 {% endif %}
-{% if allow_reauthentication is defined && allow_reauthentication%}
+{% if allow_reauthentication is defined and allow_reauthentication %}
   <p>
     <a href="{{ url_reauthentication }}">
       <button class="pure-button pure-button-red">{% trans %}Change account?{% endtrans %}</button>


### PR DESCRIPTION
The reauthentication button is always shown. The $allow_reauthentication is defined. Checking the value in the template.

src/Auth/Process/Authorize.php#L73

```
    /**
     * Flag to allow re-authentication when user is not authorized
     * @var bool
     */
    protected bool $allow_reauthentication = false;
```
